### PR TITLE
[FEATURE] 멱등성 키로 두번 결제 되지 않도록 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,8 @@ dependencies {
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/study/paymentserver/common/config/ObjectMapperConfig.java
+++ b/src/main/java/com/study/paymentserver/common/config/ObjectMapperConfig.java
@@ -1,0 +1,19 @@
+package com.study.paymentserver.common.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ObjectMapperConfig {
+
+    @Bean
+    public ObjectMapper objectMapper() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        return objectMapper;
+    }
+}

--- a/src/main/java/com/study/paymentserver/common/config/RedisConfig.java
+++ b/src/main/java/com/study/paymentserver/common/config/RedisConfig.java
@@ -1,0 +1,42 @@
+package com.study.paymentserver.common.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@EnableRedisRepositories
+@RequiredArgsConstructor
+public class RedisConfig {
+
+    private final ObjectMapper objectMapper;
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+
+        // Jackson 직렬화 설정
+        GenericJackson2JsonRedisSerializer serializer = new GenericJackson2JsonRedisSerializer(objectMapper);
+
+        template.setDefaultSerializer(serializer);
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(serializer);
+        template.setHashKeySerializer(new StringRedisSerializer());
+        template.setHashValueSerializer(serializer);
+
+        return template;
+    }
+
+    @Bean
+    public StringRedisTemplate stringRedisTemplate(RedisConnectionFactory connectionFactory) {
+        return new StringRedisTemplate(connectionFactory);
+    }
+}

--- a/src/main/java/com/study/paymentserver/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/study/paymentserver/common/exception/GlobalExceptionHandler.java
@@ -4,6 +4,7 @@ import com.study.paymentserver.common.response.ErrorResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingRequestHeaderException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -30,5 +31,12 @@ public class GlobalExceptionHandler {
             errorMap.put(error.getField(), error.getDefaultMessage());
         });
         return ErrorResponse.error(400, "입력데이터를 확인해주세요.",errorMap);
+    }
+
+    @ExceptionHandler(MissingRequestHeaderException.class)
+    public ResponseEntity<ErrorResponse> handleMissingRequestHeaderException(MissingRequestHeaderException e) {
+        log.info("MethodArgumentNotValidException Message: {}",e.getMessage());
+        log.info("Error occurred", e);
+        return ErrorResponse.error(400, e.getMessage());
     }
 }

--- a/src/main/java/com/study/paymentserver/domain/payment/controller/PaymentController.java
+++ b/src/main/java/com/study/paymentserver/domain/payment/controller/PaymentController.java
@@ -9,10 +9,7 @@ import com.study.paymentserver.domain.payment.service.PaymentService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/v1/payments")
@@ -22,8 +19,11 @@ public class PaymentController {
     private final PaymentService paymentService;
 
     @PostMapping
-    public ResponseEntity<ApiResponse<PaymentCreateResponse>> approvePayment(@RequestBody @Valid PaymentCreateRequest request) {
-        PaymentCreateResponse result = paymentService.approvePaymentRequest(request);
+    public ResponseEntity<ApiResponse<PaymentCreateResponse>> approvePayment(
+            @RequestBody @Valid PaymentCreateRequest request,
+            @RequestHeader(name = "idempotency-key") String idempotencyKey)
+    {
+        PaymentCreateResponse result = paymentService.approvePaymentRequest(request, idempotencyKey);
         return ApiResponse.success(result);
     }
 

--- a/src/main/java/com/study/paymentserver/domain/payment/repository/PaymentCacheRepository.java
+++ b/src/main/java/com/study/paymentserver/domain/payment/repository/PaymentCacheRepository.java
@@ -1,0 +1,32 @@
+package com.study.paymentserver.domain.payment.repository;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.study.paymentserver.domain.payment.controller.response.PaymentCreateResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.time.Duration;
+
+@Repository
+@RequiredArgsConstructor
+public class PaymentCacheRepository {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final ObjectMapper objectMapper;
+
+    public PaymentCreateResponse findByIdempotencyKey(String idempotencyKey) {
+        String key = "payment:" + idempotencyKey;
+        Object value = redisTemplate.opsForValue().get(key);
+        if(value == null) {
+            return null;
+        }
+        return objectMapper.convertValue(value, PaymentCreateResponse.class);
+    }
+
+    public void save(PaymentCreateResponse paymentCreateResponse, String idempotencyKey) {
+        String key = "payment:" + idempotencyKey;
+        redisTemplate.opsForValue().set(key, paymentCreateResponse, Duration.ofMinutes(5));
+    }
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,3 +16,8 @@ spring:
       hibernate:
         format_sql: true
     open-in-view: false
+
+  data:
+    redis:
+      host: localhost
+      port: 6379

--- a/src/main/resources/static/database/init.sql
+++ b/src/main/resources/static/database/init.sql
@@ -8,7 +8,7 @@ CREATE TABLE payment (
                          cancel_transaction_id varchar(100) COMMENT '취소용 transaction id' UNIQUE,
                          amount int DEFAULT NULL COMMENT '결제 승인 가격',
                          cancel_amount int DEFAULT NULL COMMENT '결제 취소 가격',
-                         cancel_reason varchar(1000) DEFAULT NULL COMMENT '취소 사유'
+                         cancel_reason varchar(1000) DEFAULT NULL COMMENT '취소 사유',
                          currency enum('AUD','BRL','CAD','CHF','CNY','DKK','EUR','GBP','HKD','INR','JPY','KRW','MXN','NOK','RUB','SEK','SGD','THB','USD','VND') COMMENT '통화',
                          status enum('CANCELED','CONFIRM','FAILED') COMMENT '승인 상태',
                          created_at datetime(6) DEFAULT NULL COMMENT '생성일',


### PR DESCRIPTION
## 주요 기능 
- 결제 전에 멱등성 키로 캐시에 데이터 있는지 조회
- 데이터 있으면 해당 데이터 리턴
- 없으면 db save 후에 5분 유효시간을 갖는 캐시 생성 (key: payment:{idempotency-key})

## 목적
- readTimeout으로 오류 발생시 retry 하는경우 이미 결제가 완료되는 경우도 존재할 수 있기에 오류를 방지하기 위해 적용.

## 추가 변경사항
- 지연 확률 10% 에서 5%로 하향 조정.
- 지연 시간 20s 에서 3s로 하향 조정.

issue: #6 